### PR TITLE
mpris-ctl status command

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -20,10 +21,26 @@
 #define MPRIS_METHOD_STOP          "Stop"
 #define MPRIS_METHOD_PLAY_PAUSE    "PlayPause"
 
+#define MPRIS_PNAME_PLAYBACKSTATUS "PlaybackStatus"
+#define MPRIS_PNAME_CANCONTROL     "CanControl"
+#define MPRIS_PNAME_CANGONEXT      "CanGoNext"
+#define MPRIS_PNAME_CANGOPREVIOUS  "CanGoPrevious"
+#define MPRIS_PNAME_CANPLAY        "CanPlay"
+#define MPRIS_PNAME_CANPAUSE       "CanPause"
+#define MPRIS_PNAME_CANSEEK        "CanSeek"
+#define MPRIS_PNAME_SHUFFLE        "Shuffle"
+#define MPRIS_PNAME_POSITION       "Position"
+#define MPRIS_PNAME_VOLUME         "Volume"
+#define MPRIS_PNAME_LOOPSTATUS     "LoopStatus"
+#define MPRIS_PNAME_METADATA       "Metadata"
+
+#define MPRIS_PROP_PLAYBACK_STATUS "PlaybackStatus"
 #define DBUS_DESTINATION           "org.freedesktop.DBus"
 #define DBUS_PATH                  "/"
 #define DBUS_INTERFACE             "org.freedesktop.DBus"
+#define DBUS_PROPERTIES_INTERFACE  "org.freedesktop.DBus.Properties"
 #define DBUS_METHOD_LIST_NAMES     "ListNames"
+#define DBUS_METHOD_GET_ALL        "GetAll"
 
 // The default timeout leads to hangs when calling
 //   certain players which don't seem to reply to MPRIS methods
@@ -36,6 +53,50 @@
 #define ARG_NEXT        "next"
 #define ARG_PREVIOUS    "prev"
 #define ARG_PLAY_PAUSE  "pp"
+#define ARG_STATUS      "status"
+
+#define HELP_MESSAGE    "MPRIS control, version %s\n" \
+"Usage:\n  %s COMMAND - Control running MPRIS player\n" \
+"Commands:\n"\
+"\t" ARG_HELP "\t\tThis help message\n" \
+"\t" ARG_STATUS "\t\tGet the play status\n" \
+"\t" ARG_PLAY_PAUSE "\t\tToggle play or pause\n" \
+"\t" ARG_PAUSE "\t\tPause the player\n" \
+"\t" ARG_STOP "\t\tStop the player\n" \
+"\t" ARG_NEXT "\t\tChange track to the next in the playlist\n" \
+"\t" ARG_PREVIOUS "\t\tChange track to the previous in the playlist\n"
+
+typedef struct mpris_metadata {
+    int track_number;
+    int* audio_bpm;
+    int disc_number;
+    int length; // mpris specific
+    char** album_artist;
+    char** composer;
+    char** genre;
+    char* album;
+    char* artist;
+    char* content_created;
+    char* title;
+    char* url;
+    char* art_url; //mpris specific
+
+} mpris_metadata;
+
+typedef struct mpris_properties {
+    mpris_metadata metadata;
+    double volume;
+    int64_t position;
+    char* loop_status;
+    char* playback_status;
+    bool can_control;
+    bool can_go_next;
+    bool can_go_previous;
+    bool can_play;
+    bool can_pause;
+    bool can_seek;
+    bool shuffle;
+} mpris_properties;
 
 const char* get_version()
 {
@@ -43,6 +104,15 @@ const char* get_version()
 #define VERSION_HASH "(unknown)"
 #endif
     return VERSION_HASH;
+}
+
+const char* get_dbus_property_name (char* command)
+{
+    if (NULL == command) return NULL;
+    if (strcmp(command, ARG_STATUS) == 0) {
+        return MPRIS_PROP_PLAYBACK_STATUS;
+    }
+    return NULL;
 }
 
 const char* get_dbus_method (char* command)
@@ -67,6 +137,9 @@ const char* get_dbus_method (char* command)
     if (strcmp(command, ARG_PLAY_PAUSE) == 0) {
         return MPRIS_METHOD_PLAY_PAUSE;
     }
+    if (strcmp(command, ARG_STATUS) == 0) {
+        return DBUS_PROPERTIES_INTERFACE;
+    }
 
     return NULL;
 }
@@ -76,15 +149,7 @@ void print_help(char* name)
     const char* help_msg;
     const char* version = get_version();
 
-    help_msg = "MPRIS control, version %s\n" \
-               "Usage:\n  %s COMMAND - Control running MPRIS player\n" \
-               "Commands:\n"
-               "  " ARG_HELP "\t\tThis help message\n" \
-               "  " ARG_PLAY_PAUSE "\t\tToggle play or pause\n" \
-               "  " ARG_PAUSE "\t\tPause the player\n" \
-               "  " ARG_STOP "\t\tStop the player\n" \
-               "  " ARG_NEXT "\t\tChange track to the next in the playlist\n" \
-               "  " ARG_PREVIOUS "\t\tChange track to the previous in the playlist\n";
+    help_msg = HELP_MESSAGE;
 
 
     fprintf(stdout, help_msg, version, name);
@@ -92,6 +157,8 @@ void print_help(char* name)
 
 DBusMessage* call_dbus_method(DBusConnection* conn, char* destination, char* path, char* interface, char* method)
 {
+    if (NULL == conn) { return NULL; }
+
     DBusMessage* msg;
     DBusPendingCall* pending;
 
@@ -128,8 +195,236 @@ DBusMessage* call_dbus_method(DBusConnection* conn, char* destination, char* pat
     return reply;
 }
 
-char* get_player_name(DBusConnection* conn) {
+double extract_double_var(DBusMessageIter *iter, DBusError *error)
+{
+    double result;
+
+    if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
+        }
+        return 0;
+    }
+
+    DBusMessageIter variantIter;
+    dbus_message_iter_recurse(iter, &variantIter);
+    if (DBUS_TYPE_DOUBLE != dbus_message_iter_get_arg_type(&variantIter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "variant_should_be_double", "This variant reply message must have double content");
+        }
+        return 0;
+    }
+    dbus_message_iter_get_basic(&variantIter, &result);
+    return result;
+}
+
+char* extract_string_var(DBusMessageIter *iter, DBusError *error)
+{
+    char* result;
+    if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
+        }
+        return NULL;
+    }
+
+    DBusMessageIter variantIter;
+    dbus_message_iter_recurse(iter, &variantIter);
+    if (DBUS_TYPE_STRING != dbus_message_iter_get_arg_type(&variantIter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "variant_should_be_string", "This variant reply message must have string content");
+        }
+        return NULL;
+    }
+    dbus_message_iter_get_basic(&variantIter, &result);
+    return result;
+}
+
+int64_t extract_int64_var(DBusMessageIter *iter, DBusError *error)
+{
+    int64_t result;
+    if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
+        }
+        return 0;
+    }
+
+    DBusMessageIter variantIter;
+    dbus_message_iter_recurse(iter, &variantIter);
+
+    if (DBUS_TYPE_INT64 != dbus_message_iter_get_arg_type(&variantIter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "variant_should_be_int32", "This variant reply message must have int32 content");
+        }
+        return 0;
+    }
+    dbus_message_iter_get_basic(&variantIter, &result);
+    return result;
+}
+
+bool extract_boolean_var(DBusMessageIter *iter,  DBusError *error)
+{
+    bool *result;
+
+    if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
+        }
+        return false;
+    }
+
+    DBusMessageIter variantIter;
+    dbus_message_iter_recurse(iter, &variantIter);
+
+    if (DBUS_TYPE_BOOLEAN != dbus_message_iter_get_arg_type(&variantIter)) {
+        if (NULL != error) {
+            dbus_set_error_const(error, "variant_should_be_boolean", "This variant reply message must have boolean content");
+        }
+        return false;
+    }
+    dbus_message_iter_get_basic(&variantIter, &result);
+    return result;
+}
+
+mpris_properties get_mpris_properties(DBusConnection* conn, char* destination)
+{
+    mpris_properties properties = {};
+    properties.playback_status = "unknown";
+    if (NULL == conn) { return properties; }
+
+    DBusMessage* msg;
+    DBusPendingCall* pending;
+    DBusMessageIter params;
+
+    char* interface = DBUS_PROPERTIES_INTERFACE;
+    char* method = DBUS_METHOD_GET_ALL;
+    char* path = MPRIS_PLAYER_PATH;
+    char* arg_interface = MPRIS_PLAYER_INTERFACE;
+
+    // create a new method call and check for errors
+    msg = dbus_message_new_method_call(destination, path, interface, method);
+    if (NULL == msg) { return properties; }
+
+    // append interface we want to get the property from
+    dbus_message_iter_init_append(msg, &params);
+    if (!dbus_message_iter_append_basic(&params, DBUS_TYPE_STRING, &arg_interface)) {
+        fprintf(stderr, "Out Of Memory!\n");
+    }
+
+    // send message and get a handle for a reply
+    if (!dbus_connection_send_with_reply (conn, msg, &pending, DBUS_CONNECTION_TIMEOUT)) {
+        fprintf(stderr, "Out Of Memory!\n");
+    }
+    if (NULL == pending) {
+        fprintf(stderr, "Pending Call Null\n");
+    }
+
+    // free message
+    dbus_message_unref(msg);
+
+    // block until we receive a reply
+    dbus_pending_call_block(pending);
+
+    DBusMessage* reply;
+    // get the reply message
+    reply = dbus_pending_call_steal_reply(pending);
+    if (NULL == reply) {
+        fprintf(stderr, "Reply Null\n");
+    }
+
+    // free the pending message handle
+    dbus_pending_call_unref(pending);
+
+    DBusMessageIter rootIter;
+    if (dbus_message_iter_init(reply, &rootIter) && DBUS_TYPE_ARRAY == dbus_message_iter_get_arg_type(&rootIter)) {
+        DBusMessageIter arrayElementIter;
+
+        dbus_message_iter_recurse(&rootIter, &arrayElementIter);
+        while (true) {
+            char* key;
+            if (DBUS_TYPE_DICT_ENTRY == dbus_message_iter_get_arg_type(&arrayElementIter)) {
+                DBusError *err = 0;
+                DBusMessageIter dictIter;
+                dbus_message_iter_recurse(&arrayElementIter, &dictIter);
+                if (DBUS_TYPE_STRING != dbus_message_iter_get_arg_type(&dictIter)) {
+                    dbus_set_error_const(err, "missing_key", "This message iterator doesn't have key");
+                }
+                dbus_message_iter_get_basic(&dictIter, &key);
+
+                if (!dbus_message_iter_has_next(&dictIter)) {
+                    continue;
+                }
+                dbus_message_iter_next(&dictIter);
+
+                if (!strncmp(key, MPRIS_PNAME_CANCONTROL, strlen(MPRIS_PNAME_CANCONTROL))) {
+                     properties.can_control = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_CANGONEXT, strlen(MPRIS_PNAME_CANGONEXT))) {
+                     properties.can_go_next = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_CANGOPREVIOUS, strlen(MPRIS_PNAME_CANGOPREVIOUS))) {
+                   properties.can_go_previous = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_CANPAUSE, strlen(MPRIS_PNAME_CANPAUSE))) {
+                    properties.can_pause = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_CANPLAY, strlen(MPRIS_PNAME_CANPLAY))) {
+                    properties.can_play = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_CANSEEK, strlen(MPRIS_PNAME_CANSEEK))) {
+                    properties.can_seek = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_LOOPSTATUS, strlen(MPRIS_PNAME_LOOPSTATUS))) {
+                    properties.loop_status = extract_string_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_METADATA, strlen(MPRIS_PNAME_METADATA))) {
+                }
+                if (!strncmp(key, MPRIS_PNAME_PLAYBACKSTATUS, strlen(MPRIS_PNAME_PLAYBACKSTATUS))) {
+                     properties.playback_status = extract_string_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_POSITION, strlen(MPRIS_PNAME_POSITION))) {
+                      properties.position= extract_int64_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_SHUFFLE, strlen(MPRIS_PNAME_SHUFFLE))) {
+                    properties.shuffle = extract_boolean_var(&dictIter, err);
+                }
+                if (!strncmp(key, MPRIS_PNAME_VOLUME, strlen(MPRIS_PNAME_VOLUME))) {
+                     properties.volume = extract_double_var(&dictIter, err);
+                }
+                if (NULL != err) {
+                    fprintf(stderr, "%s\n", err->message);
+                }
+            }
+            if (!dbus_message_iter_has_next(&arrayElementIter)) {
+                break;
+            }
+            dbus_message_iter_next(&arrayElementIter);
+        }
+    }
+
+    return properties;
+}
+
+char* get_dbus_string_scalar(DBusMessage* message)
+{
+    if (NULL == message) { return NULL; }
+    char* status;
+
+    DBusMessageIter rootIter;
+    if (dbus_message_iter_init(message, &rootIter) &&
+        DBUS_TYPE_STRING == dbus_message_iter_get_arg_type(&rootIter)) {
+
+        dbus_message_iter_get_basic(&rootIter, &status);
+    }
+
+    return status;
+}
+
+char* get_player_name(DBusConnection* conn)
+{
     if (NULL == conn) { return NULL; }
+
     char* player_name = "";
 
     char* method = DBUS_METHOD_LIST_NAMES;
@@ -146,7 +441,7 @@ char* get_player_name(DBusConnection* conn) {
         DBusMessageIter arrayElementIter;
 
         dbus_message_iter_recurse(&rootIter, &arrayElementIter);
-        while (dbus_message_iter_has_next(&arrayElementIter)) {
+        while (true) {
             if (DBUS_TYPE_STRING == dbus_message_iter_get_arg_type(&arrayElementIter)) {
                 char* str;
                 dbus_message_iter_get_basic(&arrayElementIter, &str);
@@ -154,6 +449,9 @@ char* get_player_name(DBusConnection* conn) {
                     player_name = str;
                     break;
                 }
+            }
+            if (!dbus_message_iter_has_next(&arrayElementIter)) {
+                break;
             }
             dbus_message_iter_next(&arrayElementIter);
         }
@@ -179,6 +477,9 @@ int main(int argc, char** argv)
         fprintf(stderr, "Invalid command %s (use help for help)\n", command);
         goto _error;
     }
+    char *dbus_property = NULL;
+    dbus_property = (char*)get_dbus_property_name(command);
+
     DBusConnection* conn;
     DBusError err;
 
@@ -208,12 +509,17 @@ int main(int argc, char** argv)
     }
 
     char* destination = get_player_name(conn);
-    if (NULL == destination) { goto _error; }
+    if (strlen(destination) == 0) { goto _error; }
 
-    call_dbus_method(conn, destination,
-                           MPRIS_PLAYER_PATH,
-                           MPRIS_PLAYER_INTERFACE,
-                           dbus_method);
+    if (NULL == dbus_property) {
+        call_dbus_method(conn, destination,
+                         MPRIS_PLAYER_PATH,
+                         MPRIS_PLAYER_INTERFACE,
+                         dbus_method);
+    } else {
+        mpris_properties prop = get_mpris_properties(conn, destination);
+        fprintf(stdout, "%s\n", prop.playback_status);
+    }
 
     dbus_connection_flush(conn);
 

--- a/main.c
+++ b/main.c
@@ -200,18 +200,14 @@ double extract_double_var(DBusMessageIter *iter, DBusError *error)
     double result;
 
     if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
-        }
+        dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
         return 0;
     }
 
     DBusMessageIter variantIter;
     dbus_message_iter_recurse(iter, &variantIter);
     if (DBUS_TYPE_DOUBLE != dbus_message_iter_get_arg_type(&variantIter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "variant_should_be_double", "This variant reply message must have double content");
-        }
+        dbus_set_error_const(error, "variant_should_be_double", "This variant reply message must have double content");
         return 0;
     }
     dbus_message_iter_get_basic(&variantIter, &result);
@@ -222,18 +218,14 @@ char* extract_string_var(DBusMessageIter *iter, DBusError *error)
 {
     char* result;
     if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
-        }
+        dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
         return NULL;
     }
 
     DBusMessageIter variantIter;
     dbus_message_iter_recurse(iter, &variantIter);
     if (DBUS_TYPE_STRING != dbus_message_iter_get_arg_type(&variantIter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "variant_should_be_string", "This variant reply message must have string content");
-        }
+        dbus_set_error_const(error, "variant_should_be_string", "This variant reply message must have string content");
         return NULL;
     }
     dbus_message_iter_get_basic(&variantIter, &result);
@@ -244,9 +236,7 @@ int64_t extract_int64_var(DBusMessageIter *iter, DBusError *error)
 {
     int64_t result;
     if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
-        }
+        dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
         return 0;
     }
 
@@ -254,9 +244,7 @@ int64_t extract_int64_var(DBusMessageIter *iter, DBusError *error)
     dbus_message_iter_recurse(iter, &variantIter);
 
     if (DBUS_TYPE_INT64 != dbus_message_iter_get_arg_type(&variantIter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "variant_should_be_int32", "This variant reply message must have int32 content");
-        }
+        dbus_set_error_const(error, "variant_should_be_int32", "This variant reply message must have int32 content");
         return 0;
     }
     dbus_message_iter_get_basic(&variantIter, &result);
@@ -268,9 +256,7 @@ bool extract_boolean_var(DBusMessageIter *iter,  DBusError *error)
     bool *result;
 
     if (DBUS_TYPE_VARIANT != dbus_message_iter_get_arg_type(iter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
-        }
+        dbus_set_error_const(error, "iter_should_be_variant", "This message iterator must be have variant type");
         return false;
     }
 
@@ -278,9 +264,7 @@ bool extract_boolean_var(DBusMessageIter *iter,  DBusError *error)
     dbus_message_iter_recurse(iter, &variantIter);
 
     if (DBUS_TYPE_BOOLEAN != dbus_message_iter_get_arg_type(&variantIter)) {
-        if (NULL != error) {
-            dbus_set_error_const(error, "variant_should_be_boolean", "This variant reply message must have boolean content");
-        }
+        dbus_set_error_const(error, "variant_should_be_boolean", "This variant reply message must have boolean content");
         return false;
     }
     dbus_message_iter_get_basic(&variantIter, &result);
@@ -344,11 +328,11 @@ mpris_properties get_mpris_properties(DBusConnection* conn, char* destination)
         while (true) {
             char* key;
             if (DBUS_TYPE_DICT_ENTRY == dbus_message_iter_get_arg_type(&arrayElementIter)) {
-                DBusError *err = 0;
+                DBusError err = {};
                 DBusMessageIter dictIter;
                 dbus_message_iter_recurse(&arrayElementIter, &dictIter);
                 if (DBUS_TYPE_STRING != dbus_message_iter_get_arg_type(&dictIter)) {
-                    dbus_set_error_const(err, "missing_key", "This message iterator doesn't have key");
+                    dbus_set_error_const(&err, "missing_key", "This message iterator doesn't have key");
                 }
                 dbus_message_iter_get_basic(&dictIter, &key);
 
@@ -358,42 +342,43 @@ mpris_properties get_mpris_properties(DBusConnection* conn, char* destination)
                 dbus_message_iter_next(&dictIter);
 
                 if (!strncmp(key, MPRIS_PNAME_CANCONTROL, strlen(MPRIS_PNAME_CANCONTROL))) {
-                     properties.can_control = extract_boolean_var(&dictIter, err);
+                     properties.can_control = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_CANGONEXT, strlen(MPRIS_PNAME_CANGONEXT))) {
-                     properties.can_go_next = extract_boolean_var(&dictIter, err);
+                     properties.can_go_next = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_CANGOPREVIOUS, strlen(MPRIS_PNAME_CANGOPREVIOUS))) {
-                   properties.can_go_previous = extract_boolean_var(&dictIter, err);
+                   properties.can_go_previous = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_CANPAUSE, strlen(MPRIS_PNAME_CANPAUSE))) {
-                    properties.can_pause = extract_boolean_var(&dictIter, err);
+                    properties.can_pause = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_CANPLAY, strlen(MPRIS_PNAME_CANPLAY))) {
-                    properties.can_play = extract_boolean_var(&dictIter, err);
+                    properties.can_play = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_CANSEEK, strlen(MPRIS_PNAME_CANSEEK))) {
-                    properties.can_seek = extract_boolean_var(&dictIter, err);
+                    properties.can_seek = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_LOOPSTATUS, strlen(MPRIS_PNAME_LOOPSTATUS))) {
-                    properties.loop_status = extract_string_var(&dictIter, err);
+                    properties.loop_status = extract_string_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_METADATA, strlen(MPRIS_PNAME_METADATA))) {
                 }
                 if (!strncmp(key, MPRIS_PNAME_PLAYBACKSTATUS, strlen(MPRIS_PNAME_PLAYBACKSTATUS))) {
-                     properties.playback_status = extract_string_var(&dictIter, err);
+                     properties.playback_status = extract_string_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_POSITION, strlen(MPRIS_PNAME_POSITION))) {
-                      properties.position= extract_int64_var(&dictIter, err);
+                      properties.position= extract_int64_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_SHUFFLE, strlen(MPRIS_PNAME_SHUFFLE))) {
-                    properties.shuffle = extract_boolean_var(&dictIter, err);
+                    properties.shuffle = extract_boolean_var(&dictIter, &err);
                 }
                 if (!strncmp(key, MPRIS_PNAME_VOLUME, strlen(MPRIS_PNAME_VOLUME))) {
-                     properties.volume = extract_double_var(&dictIter, err);
+                     properties.volume = extract_double_var(&dictIter, &err);
                 }
-                if (NULL != err) {
-                    fprintf(stderr, "%s\n", err->message);
+                if (dbus_error_is_set(&err)) {
+                    fprintf(stderr, "error: %s\n", err.message);
+                    dbus_error_free(&err);
                 }
             }
             if (!dbus_message_iter_has_next(&arrayElementIter)) {

--- a/main.c
+++ b/main.c
@@ -45,7 +45,7 @@ const char* get_version()
     return VERSION_HASH;
 }
 
-const char* get_dbus_method (char* command) 
+const char* get_dbus_method (char* command)
 {
     if (NULL == command) return NULL;
 
@@ -90,7 +90,7 @@ void print_help(char* name)
     fprintf(stdout, help_msg, version, name);
 }
 
-DBusMessage* call_dbus_method(DBusConnection* conn, char* destination, char* path, char* interface, char* method) 
+DBusMessage* call_dbus_method(DBusConnection* conn, char* destination, char* path, char* interface, char* method)
 {
     DBusMessage* msg;
     DBusPendingCall* pending;
@@ -98,13 +98,13 @@ DBusMessage* call_dbus_method(DBusConnection* conn, char* destination, char* pat
     // create a new method call and check for errors
     msg = dbus_message_new_method_call(destination, path, interface, method);
     if (NULL == msg) { return NULL; }
-    
+
     // send message and get a handle for a reply
     if (!dbus_connection_send_with_reply (conn, msg, &pending, DBUS_CONNECTION_TIMEOUT)) {
         fprintf(stderr, "Out Of Memory!\n");
         return NULL;
     }
-    if (NULL == pending) { 
+    if (NULL == pending) {
         fprintf(stderr, "Pending Call Null\n");
         return NULL;
     }
@@ -119,7 +119,7 @@ DBusMessage* call_dbus_method(DBusConnection* conn, char* destination, char* pat
     // get the reply message
     reply = dbus_pending_call_steal_reply(pending);
     if (NULL == reply) {
-        fprintf(stderr, "Reply Null\n"); 
+        fprintf(stderr, "Reply Null\n");
     }
 
     // free the pending message handle
@@ -137,11 +137,11 @@ char* get_player_name(DBusConnection* conn) {
     char* path = DBUS_PATH;
     char* interface = DBUS_INTERFACE;
     const char* mpris_namespace = MPRIS_PLAYER_NAMESPACE;
-    DBusMessage* reply = call_dbus_method(conn, destination, path, interface, method); 
+    DBusMessage* reply = call_dbus_method(conn, destination, path, interface, method);
     if (NULL == reply) { return NULL; }
 
     DBusMessageIter rootIter;
-    if (dbus_message_iter_init(reply, &rootIter) && 
+    if (dbus_message_iter_init(reply, &rootIter) &&
         DBUS_TYPE_ARRAY == dbus_message_iter_get_arg_type(&rootIter)) {
         DBusMessageIter arrayElementIter;
 
@@ -154,7 +154,7 @@ char* get_player_name(DBusConnection* conn) {
                     player_name = str;
                     break;
                 }
-            } 
+            }
             dbus_message_iter_next(&arrayElementIter);
         }
     }
@@ -162,13 +162,13 @@ char* get_player_name(DBusConnection* conn) {
     return player_name;
 }
 
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
     char* name = argv[0];
     if (argc <= 1) {
         goto _help;
     }
-    
+
     char *command = argv[1];
     if (strcmp(command, ARG_HELP) == 0) {
         goto _help;
@@ -187,45 +187,45 @@ int main(int argc, char** argv)
 
     // connect to the system bus and check for errors
     conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
-    if (dbus_error_is_set(&err)) { 
+    if (dbus_error_is_set(&err)) {
         fprintf(stderr, "Connection error(%s)\n", err.message);
         dbus_error_free(&err);
     }
-    if (NULL == conn) { 
+    if (NULL == conn) {
         goto _error;
     }
 
     // request a name on the bus
-    int ret = dbus_bus_request_name(conn, LOCAL_NAME, 
+    int ret = dbus_bus_request_name(conn, LOCAL_NAME,
                                DBUS_NAME_FLAG_REPLACE_EXISTING,
                                &err);
-    if (dbus_error_is_set(&err)) { 
+    if (dbus_error_is_set(&err)) {
         fprintf(stderr, "Name error(%s)\n", err.message);
-        dbus_error_free(&err); 
+        dbus_error_free(&err);
     }
-    if (DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER != ret) { 
+    if (DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER != ret) {
         goto _error;
     }
 
     char* destination = get_player_name(conn);
     if (NULL == destination) { goto _error; }
-    
-    call_dbus_method(conn, destination, 
-                           MPRIS_PLAYER_PATH, 
-                           MPRIS_PLAYER_INTERFACE, 
-                           dbus_method); 
+
+    call_dbus_method(conn, destination,
+                           MPRIS_PLAYER_PATH,
+                           MPRIS_PLAYER_INTERFACE,
+                           dbus_method);
 
     dbus_connection_flush(conn);
 
-    _success: 
+    _success:
     {
         return EXIT_SUCCESS;
     }
-    _error: 
+    _error:
     {
         return EXIT_FAILURE;
     }
-    _help: 
+    _help:
     {
         print_help(name);
         goto _success;


### PR DESCRIPTION
Implements #3, but reports directly the MPRIS status. 

There's no special case for when there's no suitable player found.