### PR TITLE
Implementing static testing using clang sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
 language: c
 
 dist: trusty
+sudo: false
 
 compiler:
   - clang-3.8
 
 script:
     - make check_leak
-    - make check_memory
-    - make check_thread
-    - make check_undefined
+#    - make check_memory
+#    - make check_thread
+#    - make check_undefined
 
 env:
   global:
    - secure: "56PTl/WyduIZ0khwtLuPgS/0+MHBprftcuFcwdMSI4NVxXjbUgpArRn4fWSlfzVtss45rBUtZzJw8f508dWh5HJSnbQGrgFNlOxxdof/5O972wiOIohTMuhs3kdI4H0qLj9OBgZAWNGKUyHI2haBafOuOH/xAoNA7gY+sE4slbXEgCDQbqRzvLPizQmQYkNNKmZezIMHaJTpETnUysopNEqZKmEfV61QPLHOM+SGbN0oOd0x1MYwKSC0AX4H6maRv3DNWOn09/6CQSiHuCDKkdQRTLfQ10IZw7kInjFEzeCigEfybDCb2Ceb5rfrQWwSZsqbWe1TMzwXp8beGpYT5zaY2FDKYhxUbrMq4rqKtR+6vUVmDokz7mmFLEnDC8YohUi+lK/CHX3zKOrYdHaxsrXkzP5FeLHXlTjnRVwRRFenpFH7T/wsBngMVDDwMbpO87SRcM7X6f4M8SqxKbaTvRJh57nWd4KjhA3ohXLIJMH+Cy8rCm3PIov1IxIB0y0Y1Xyckfxt+RXsjCo/TlEhURNud8E6Yky2H0ERihBttinuiCiPa5Wa6EhE9XXe7iQx1kZ/hp9w4KmTRzGlAYIBBP644QuzaJAKHRqGH19ULhU1SkMx+yne480Yet/uJKQH+WgklV/df4xUruG2YRjg59UHbPHzamjGtZacQwWO5CE="
 
 before_install:
-      - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+#      - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
    - secure: "56PTl/WyduIZ0khwtLuPgS/0+MHBprftcuFcwdMSI4NVxXjbUgpArRn4fWSlfzVtss45rBUtZzJw8f508dWh5HJSnbQGrgFNlOxxdof/5O972wiOIohTMuhs3kdI4H0qLj9OBgZAWNGKUyHI2haBafOuOH/xAoNA7gY+sE4slbXEgCDQbqRzvLPizQmQYkNNKmZezIMHaJTpETnUysopNEqZKmEfV61QPLHOM+SGbN0oOd0x1MYwKSC0AX4H6maRv3DNWOn09/6CQSiHuCDKkdQRTLfQ10IZw7kInjFEzeCigEfybDCb2Ceb5rfrQWwSZsqbWe1TMzwXp8beGpYT5zaY2FDKYhxUbrMq4rqKtR+6vUVmDokz7mmFLEnDC8YohUi+lK/CHX3zKOrYdHaxsrXkzP5FeLHXlTjnRVwRRFenpFH7T/wsBngMVDDwMbpO87SRcM7X6f4M8SqxKbaTvRJh57nWd4KjhA3ohXLIJMH+Cy8rCm3PIov1IxIB0y0Y1Xyckfxt+RXsjCo/TlEhURNud8E6Yky2H0ERihBttinuiCiPa5Wa6EhE9XXe7iQx1kZ/hp9w4KmTRzGlAYIBBP644QuzaJAKHRqGH19ULhU1SkMx+yne480Yet/uJKQH+WgklV/df4xUruG2YRjg59UHbPHzamjGtZacQwWO5CE="
 
 before_install:
+      - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+      - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main" | sudo tee -a /etc/apt/sources.list
+      - sudo apt-get -qq update
+      - sudo apt-get install -y clang-3.8
       - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,23 @@ env:
    - secure: "56PTl/WyduIZ0khwtLuPgS/0+MHBprftcuFcwdMSI4NVxXjbUgpArRn4fWSlfzVtss45rBUtZzJw8f508dWh5HJSnbQGrgFNlOxxdof/5O972wiOIohTMuhs3kdI4H0qLj9OBgZAWNGKUyHI2haBafOuOH/xAoNA7gY+sE4slbXEgCDQbqRzvLPizQmQYkNNKmZezIMHaJTpETnUysopNEqZKmEfV61QPLHOM+SGbN0oOd0x1MYwKSC0AX4H6maRv3DNWOn09/6CQSiHuCDKkdQRTLfQ10IZw7kInjFEzeCigEfybDCb2Ceb5rfrQWwSZsqbWe1TMzwXp8beGpYT5zaY2FDKYhxUbrMq4rqKtR+6vUVmDokz7mmFLEnDC8YohUi+lK/CHX3zKOrYdHaxsrXkzP5FeLHXlTjnRVwRRFenpFH7T/wsBngMVDDwMbpO87SRcM7X6f4M8SqxKbaTvRJh57nWd4KjhA3ohXLIJMH+Cy8rCm3PIov1IxIB0y0Y1Xyckfxt+RXsjCo/TlEhURNud8E6Yky2H0ERihBttinuiCiPa5Wa6EhE9XXe7iQx1kZ/hp9w4KmTRzGlAYIBBP644QuzaJAKHRqGH19ULhU1SkMx+yne480Yet/uJKQH+WgklV/df4xUruG2YRjg59UHbPHzamjGtZacQwWO5CE="
 
 before_install:
-      - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-      - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main" | sudo tee -a /etc/apt/sources.list
-      - sudo apt-get -qq update
-      - sudo apt-get install -y clang-3.8
       - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:
   apt:
+    sources:
+    - sourceline: "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main"
+      key_url: http://llvm.org/apt/llvm-snapshot.gpg.key
     packages:
+    - clang-3.8
     - dbus
     - libdbus-1-dev
 
-  coverity_scan:
-    project:
-      name: "mariusor/mpris-ctl"
-      description: "Build submitted via Travis CI"
-    notification_email: marius@habarnam.ro
-    build_command_prepend: "make clean"
-    build_command:   "make -j 4"
-    branch_pattern: master
+#  coverity_scan:
+#    project:
+#      name: "mariusor/mpris-ctl"
+#      description: "Build submitted via Travis CI"
+#    notification_email: marius@habarnam.ro
+#    build_command_prepend: "make clean"
+#    build_command:   "make -j 4"
+#    branch_pattern: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 
 dist: trusty
-sudo: false
 
 compiler:
   - clang-3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ compiler:
 
 script:
     - make check_leak
-#    - make check_memory
     - make check_undefined
+#    - make check_memory
 
 env:
   global:
    - secure: "56PTl/WyduIZ0khwtLuPgS/0+MHBprftcuFcwdMSI4NVxXjbUgpArRn4fWSlfzVtss45rBUtZzJw8f508dWh5HJSnbQGrgFNlOxxdof/5O972wiOIohTMuhs3kdI4H0qLj9OBgZAWNGKUyHI2haBafOuOH/xAoNA7gY+sE4slbXEgCDQbqRzvLPizQmQYkNNKmZezIMHaJTpETnUysopNEqZKmEfV61QPLHOM+SGbN0oOd0x1MYwKSC0AX4H6maRv3DNWOn09/6CQSiHuCDKkdQRTLfQ10IZw7kInjFEzeCigEfybDCb2Ceb5rfrQWwSZsqbWe1TMzwXp8beGpYT5zaY2FDKYhxUbrMq4rqKtR+6vUVmDokz7mmFLEnDC8YohUi+lK/CHX3zKOrYdHaxsrXkzP5FeLHXlTjnRVwRRFenpFH7T/wsBngMVDDwMbpO87SRcM7X6f4M8SqxKbaTvRJh57nWd4KjhA3ohXLIJMH+Cy8rCm3PIov1IxIB0y0Y1Xyckfxt+RXsjCo/TlEhURNud8E6Yky2H0ERihBttinuiCiPa5Wa6EhE9XXe7iQx1kZ/hp9w4KmTRzGlAYIBBP644QuzaJAKHRqGH19ULhU1SkMx+yne480Yet/uJKQH+WgklV/df4xUruG2YRjg59UHbPHzamjGtZacQwWO5CE="
 
 before_install:
-#      - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:
   apt:
@@ -28,11 +28,11 @@ addons:
     - dbus
     - libdbus-1-dev
 
-#  coverity_scan:
-#    project:
-#      name: "mariusor/mpris-ctl"
-#      description: "Build submitted via Travis CI"
-#    notification_email: marius@habarnam.ro
-#    build_command_prepend: "make clean"
-#    build_command:   "make -j 4"
-#    branch_pattern: master
+  coverity_scan:
+    project:
+      name: "mariusor/mpris-ctl"
+      description: "Build submitted via Travis CI"
+    notification_email: marius@habarnam.ro
+    build_command_prepend: "make clean"
+    build_command:   "make -j 4"
+    branch_pattern: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ dist: trusty
 compiler:
   - clang
 
-script: make release
+script:
+    - make check_leak
+    - make check_memory
+    - make check_thread
+    - make check_undefined
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ compiler:
 script:
     - make check_leak
 #    - make check_memory
-#    - make check_thread
-#    - make check_undefined
+    - make check_undefined
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 dist: trusty
 
 compiler:
-  - clang
+  - clang-3.8
 
 script:
     - make check_leak

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ check_undefined: clean run
 
 .PHONY: run
 run: executable
-	./$(BIN_NAME) info
+	./$(BIN_NAME) info || test $$? -eq 1
 
 release: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(RCOMPILE_FLAGS)
 release: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(RLINK_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ all: release
 #check: check_leak check_memory
 
 .PHONY: check_leak
-check_leak: export CC := clang
 check_leak: DCOMPILE_FLAGS += -fsanitize=address -fPIE
 check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
@@ -40,7 +39,6 @@ check_leak: BIN_NAME := $(BIN_NAME)-test
 check_leak: clean run
 
 .PHONY: check_memory
-check_memory: export CC := clang
 check_memory: DCOMPILE_FLAGS += -fsanitize=memory -fPIE
 check_memory: DLINK_FLAGS += -pie
 check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
@@ -49,7 +47,6 @@ check_memory: BIN_NAME := $(BIN_NAME)-test
 check_memory: clean run
 
 .PHONY: check_undefined
-check_undefined: export CC := clang
 check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined -fPIE
 check_undefined: DLINK_FLAGS += -pie
 check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_leak: BIN_NAME := $(BIN_NAME)-test
-check_leak: clean executable run
+check_leak: clean run
 
 .PHONY: check_memory
 check_memory: export CC := clang
@@ -46,7 +46,7 @@ check_memory: DLINK_FLAGS += -pie
 check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_memory: BIN_NAME := $(BIN_NAME)-test
-check_memory: clean executable run
+check_memory: clean run
 
 .PHONY: check_undefined
 check_undefined: export CC := clang
@@ -55,10 +55,10 @@ check_undefined: DLINK_FLAGS += -pie
 check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_undefined: BIN_NAME := $(BIN_NAME)-test
-check_undefined: clean executable run
+check_undefined: clean run
 
 .PHONY: run
-run: $(BIN_NAME)
+run: executable
 	./$(BIN_NAME) info
 
 release: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(RCOMPILE_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_NAME := mpris-ctl
-CC ?= gcc
+CC ?= clang
 LIBS = dbus-1
 COMPILE_FLAGS = -std=c99 -Wall -Wextra
 LINK_FLAGS =
@@ -32,6 +32,45 @@ debug: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 .PHONY: all
 all: release
 
+check_leak: export CC := clang
+check_leak: DCOMPILE_FLAGS += -fsanitize=address -fPIE
+check_leak: DLINK_FLAGS += -pie
+check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+
+check_thread: export CC := clang
+check_thread: DCOMPILE_FLAGS += -fsanitize=thread -lpthread -fPIE
+check_thread: DLINK_FLAGS += -pie
+check_thread: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+check_thread: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+
+check_memory: export CC := clang
+check_memory: DCOMPILE_FLAGS += -fsanitize=memory -fPIE
+check_memory: DLINK_FLAGS += -pie
+check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+
+check_undefined: export CC := clang
+check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined -fPIE
+check_undefined: DLINK_FLAGS += -pie
+check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+
+.PHONY: check_leak
+check_leak: clean executable run
+
+.PHONY: check_thread
+check_thread: clean executable run
+
+.PHONY: check_memory
+check_memory: clean executable run
+
+.PHONY: check_undefined
+check_undefined: clean executable run
+
+run: $(BIN_NAME)
+	./$(BIN_NAME) info %full
+
 .PHONY: release
 release: executable
 
@@ -43,7 +82,7 @@ executable:
 
 .PHONY: clean
 clean:
-	@$(RM) $(BIN_NAME)
+	$(RM) $(BIN_NAME)
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIBS = dbus-1
 COMPILE_FLAGS = -std=c99 -Wall -Wextra
 LINK_FLAGS =
 RCOMPILE_FLAGS = -D NDEBUG
-DCOMPILE_FLAGS = -ggdb -D DEBUG -O1
+DCOMPILE_FLAGS = -g #-D DEBUG -O1
 RLINK_FLAGS =
 DLINK_FLAGS =
 
@@ -24,71 +24,74 @@ ifneq ($(VERSION), )
 	override CFLAGS := $(CFLAGS) -D VERSION_HASH=\"$(VERSION)\"
 endif
 
-release: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(RCOMPILE_FLAGS)
-release: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(RLINK_FLAGS)
-debug: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-debug: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
-
 .PHONY: all
 all: release
 
+#.PHONY: check
+#check: check_leak check_thread
+
+.PHONY: check_leak
 check_leak: export CC := clang
 check_leak: DCOMPILE_FLAGS += -fsanitize=address -fPIE
 check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_leak: BIN_NAME := $(BIN_NAME)-test
+check_leak: clean $(BIN_NAME) run
 
+.PHONY: check_thread
 check_thread: export CC := clang
 check_thread: DCOMPILE_FLAGS += -fsanitize=thread -lpthread -fPIE
 check_thread: DLINK_FLAGS += -pie
 check_thread: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_thread: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_thread: BIN_NAME := $(BIN_NAME)-test
+check_thread: clean $(BIN_NAME) run
 
+.PHONY: check_memory
 check_memory: export CC := clang
 check_memory: DCOMPILE_FLAGS += -fsanitize=memory -fPIE
 check_memory: DLINK_FLAGS += -pie
 check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_memory: BIN_NAME := $(BIN_NAME)-test
+check_memory: clean $(BIN_NAME) run
 
+.PHONY: check_undefined
 check_undefined: export CC := clang
 check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined -fPIE
 check_undefined: DLINK_FLAGS += -pie
 check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_undefined: BIN_NAME := $(BIN_NAME)-test
+check_undefined: clean $(BIN_NAME) run
 
-.PHONY: check_leak
-check_leak: clean executable run
-
-.PHONY: check_thread
-check_thread: clean executable run
-
-.PHONY: check_memory
-check_memory: clean executable run
-
-.PHONY: check_undefined
-check_undefined: clean executable run
-
+.PHONY: run
 run: $(BIN_NAME)
-	./$(BIN_NAME) info %full
+	./$(BIN_NAME) info
+
+release: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(RCOMPILE_FLAGS)
+release: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(RLINK_FLAGS)
+debug: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+debug: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 
 .PHONY: release
-release: executable
+release: $(BIN_NAME)
 
 .PHONY: debug
-debug: executable
-
-executable:
-	$(CC) $(CFLAGS) $(INCLUDES) $(SOURCES) $(LDFLAGS) -o$(BIN_NAME)
+debug: $(BIN_NAME)
 
 .PHONY: clean
 clean:
 	$(RM) $(BIN_NAME)
 
 .PHONY: install
-install:
+install: $(BIN_NAME)
 	install $(BIN_NAME) $(DESTDIR)$(INSTALL_PREFIX)/bin
 
 .PHONY: uninstall
 uninstall:
 	$(RM) $(DESTDIR)$(INSTALL_PREFIX)/bin/$(BIN_NAME)
 
+$(BIN_NAME):
+	$(CC) $(CFLAGS) $(INCLUDES) $(SOURCES) $(LDFLAGS) -o$(BIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 all: release
 
 #.PHONY: check
-#check: check_leak check_thread
+#check: check_leak check_memory
 
 .PHONY: check_leak
 check_leak: export CC := clang
@@ -37,16 +37,7 @@ check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_leak: BIN_NAME := $(BIN_NAME)-test
-check_leak: clean $(BIN_NAME) run
-
-.PHONY: check_thread
-check_thread: export CC := clang
-check_thread: DCOMPILE_FLAGS += -fsanitize=thread -lpthread -fPIE
-check_thread: DLINK_FLAGS += -pie
-check_thread: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-check_thread: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
-check_thread: BIN_NAME := $(BIN_NAME)-test
-check_thread: clean $(BIN_NAME) run
+check_leak: clean executable run
 
 .PHONY: check_memory
 check_memory: export CC := clang
@@ -55,7 +46,7 @@ check_memory: DLINK_FLAGS += -pie
 check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_memory: BIN_NAME := $(BIN_NAME)-test
-check_memory: clean $(BIN_NAME) run
+check_memory: clean executable run
 
 .PHONY: check_undefined
 check_undefined: export CC := clang
@@ -64,7 +55,7 @@ check_undefined: DLINK_FLAGS += -pie
 check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_undefined: BIN_NAME := $(BIN_NAME)-test
-check_undefined: clean $(BIN_NAME) run
+check_undefined: clean executable run
 
 .PHONY: run
 run: $(BIN_NAME)
@@ -76,10 +67,10 @@ debug: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 debug: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 
 .PHONY: release
-release: $(BIN_NAME)
+release: executable
 
 .PHONY: debug
-debug: $(BIN_NAME)
+debug: executable
 
 .PHONY: clean
 clean:
@@ -93,5 +84,6 @@ install: $(BIN_NAME)
 uninstall:
 	$(RM) $(DESTDIR)$(INSTALL_PREFIX)/bin/$(BIN_NAME)
 
-$(BIN_NAME):
+.PHONY: executable
+executable:
 	$(CC) $(CFLAGS) $(INCLUDES) $(SOURCES) $(LDFLAGS) -o$(BIN_NAME)


### PR DESCRIPTION
Using clang compile time [sanitizers](/google/sanitizers) for enabling some CI static testing.

Check the [wiki](/google/sanitizers/wiki) for more details.

Again, thanx to @iambrosie for suggestions and help.