### PR TITLE
The PIE is a lie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
     packages:
     - clang-3.8
     - dbus
+    - dbus-tests
     - libdbus-1-dev
 
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,10 @@ dist: trusty
 compiler:
   - clang-3.8
 
-before_script:
-    - dbus-test-tool echo --name=org.mpris.MediaPlayer2.Player.atest & >/dev/null
-
 script:
     - make check_leak
     - make check_undefined
-#    - make check_memory
+    - make check_memory
 
 env:
   global:
@@ -28,7 +25,6 @@ addons:
     packages:
     - clang-3.8
     - dbus
-    - dbus-tests
     - libdbus-1-dev
 
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 compiler:
   - clang-3.8
 
+before_script:
+    - dbus-test-tool echo --name=org.mpris.MediaPlayer2.Player.atest & >/dev/null
+
 script:
     - make check_leak
     - make check_undefined

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ check_memory: DCOMPILE_FLAGS += -fsanitize=memory #-fPIE
 check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 #check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_memory: BIN_NAME := $(BIN_NAME)-test
-check_memory: clean debug run
+check_memory: clean run
 
 .PHONY: check_undefined
 check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined #-fPIE
@@ -52,7 +52,7 @@ check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined #-fPIE
 check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 #check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_undefined: BIN_NAME := $(BIN_NAME)-test
-check_undefined: clean debug run
+check_undefined: clean run
 
 .PHONY: run
 run: executable

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,14 @@ all: release
 check_leak: DCOMPILE_FLAGS += -fsanitize=address #-fPIE
 #check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+#check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_leak: BIN_NAME := $(BIN_NAME)-test
 check_leak: clean run
 
 .PHONY: check_memory
 check_memory: DCOMPILE_FLAGS += -fsanitize=memory #-fPIE
 #check_memory: DLINK_FLAGS += -pie
-#check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 #check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_memory: BIN_NAME := $(BIN_NAME)-test
 check_memory: clean debug run
@@ -49,7 +49,7 @@ check_memory: clean debug run
 .PHONY: check_undefined
 check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined #-fPIE
 #check_undefined: DLINK_FLAGS += -pie
-#check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 #check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_undefined: BIN_NAME := $(BIN_NAME)-test
 check_undefined: clean debug run

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ all: release
 #check: check_leak check_memory
 
 .PHONY: check_leak
-#check_leak: DCOMPILE_FLAGS += -fsanitize=address -fPIE
+check_leak: DCOMPILE_FLAGS += -fsanitize=address #-fPIE
 #check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
@@ -39,7 +39,7 @@ check_leak: BIN_NAME := $(BIN_NAME)-test
 check_leak: clean run
 
 .PHONY: check_memory
-#check_memory: DCOMPILE_FLAGS += -fsanitize=memory -fPIE
+check_memory: DCOMPILE_FLAGS += -fsanitize=memory #-fPIE
 #check_memory: DLINK_FLAGS += -pie
 #check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 #check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
@@ -47,7 +47,7 @@ check_memory: BIN_NAME := $(BIN_NAME)-test
 check_memory: clean debug run
 
 .PHONY: check_undefined
-#check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined -fPIE
+check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined #-fPIE
 #check_undefined: DLINK_FLAGS += -pie
 #check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 #check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -31,28 +31,28 @@ all: release
 #check: check_leak check_memory
 
 .PHONY: check_leak
-check_leak: DCOMPILE_FLAGS += -fsanitize=address -fPIE
-check_leak: DLINK_FLAGS += -pie
+#check_leak: DCOMPILE_FLAGS += -fsanitize=address -fPIE
+#check_leak: DLINK_FLAGS += -pie
 check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
 check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_leak: BIN_NAME := $(BIN_NAME)-test
 check_leak: clean run
 
 .PHONY: check_memory
-check_memory: DCOMPILE_FLAGS += -fsanitize=memory -fPIE
-check_memory: DLINK_FLAGS += -pie
-check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+#check_memory: DCOMPILE_FLAGS += -fsanitize=memory -fPIE
+#check_memory: DLINK_FLAGS += -pie
+#check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+#check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_memory: BIN_NAME := $(BIN_NAME)-test
-check_memory: clean run
+check_memory: clean debug run
 
 .PHONY: check_undefined
-check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined -fPIE
-check_undefined: DLINK_FLAGS += -pie
-check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+#check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined -fPIE
+#check_undefined: DLINK_FLAGS += -pie
+#check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
+#check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
 check_undefined: BIN_NAME := $(BIN_NAME)-test
-check_undefined: clean run
+check_undefined: clean debug run
 
 .PHONY: run
 run: executable

--- a/Makefile
+++ b/Makefile
@@ -31,26 +31,17 @@ all: release
 #check: check_leak check_memory
 
 .PHONY: check_leak
-check_leak: DCOMPILE_FLAGS += -fsanitize=address #-fPIE
-#check_leak: DLINK_FLAGS += -pie
-check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-#check_leak: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_leak: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS) -fsanitize=address
 check_leak: BIN_NAME := $(BIN_NAME)-test
 check_leak: clean run
 
 .PHONY: check_memory
-check_memory: DCOMPILE_FLAGS += -fsanitize=memory #-fPIE
-#check_memory: DLINK_FLAGS += -pie
-check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-#check_memory: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_memory: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS) -fsanitize=memory
 check_memory: BIN_NAME := $(BIN_NAME)-test
 check_memory: clean run
 
 .PHONY: check_undefined
-check_undefined: DCOMPILE_FLAGS += -fsanitize=undefined #-fPIE
-#check_undefined: DLINK_FLAGS += -pie
-check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS)
-#check_undefined: export LDFLAGS := $(LDFLAGS) $(LINK_FLAGS) $(DLINK_FLAGS)
+check_undefined: export CFLAGS := $(CFLAGS) $(COMPILE_FLAGS) $(DCOMPILE_FLAGS) -fsanitize=undefined
 check_undefined: BIN_NAME := $(BIN_NAME)-test
 check_undefined: clean run
 

--- a/src/sdbus.h
+++ b/src/sdbus.h
@@ -372,13 +372,13 @@ char* get_player_identity(DBusConnection *conn, const char* destination)
 {
     if (NULL == conn) { return NULL; }
     if (NULL == destination) { return NULL; }
-    //if (strncmp(MPRIS_PLAYER_NAMESPACE, destination, strlen(MPRIS_PLAYER_NAMESPACE))) { return NULL; }
+    if (strncmp(MPRIS_PLAYER_NAMESPACE, destination, strlen(MPRIS_PLAYER_NAMESPACE))) { return NULL; }
 
     DBusMessage* msg;
     DBusError err;
     DBusPendingCall* pending;
     DBusMessageIter params;
-    char* result = NULL;
+    char* result = "unknown";
 
     char* interface = DBUS_PROPERTIES_INTERFACE;
     char* method = DBUS_METHOD_GET;


### PR DESCRIPTION
Removing the PIE related flags, as they weren't really needed but the trusty clang version was giving errors and suggesting PIE as a fix. 